### PR TITLE
Handles child window via webViewCreateWebViewWithConfigurationForNavi…

### DIFF
--- a/src/webview-ext.ios.ts
+++ b/src/webview-ext.ios.ts
@@ -14,23 +14,6 @@ export const useWKWebView = typeof CustomUrlSchemeHandler !== "undefined";
 export class WebViewExt extends WebViewExtBase {
     protected nativeWrapper: IOSWebViewWrapper;
 
-
-
-    constructor() {
-        super();
-    }
-
-    public loadView() {
-        console.log("WebViewExt loadView()");
-        if (this.viewController && this.nativeWrapper) {
-            this.viewController.view = (<any>this.nativeWrapper).ios;
-        }
-    }
-
-    public getNativeWrapper() {
-        return this.nativeWrapper;
-    }
-
     public get isUIWebView() {
         return !useWKWebView;
     }
@@ -56,9 +39,6 @@ export class WebViewExt extends WebViewExtBase {
     }
 
     public disposeNativeView() {
-        if (this.ios && this.ios.navigationDelegate) this.ios.navigationDelegate = null;
-        if (this.ios && this.ios.scrollView.delegate) this.ios.scrollView.delegate = null;
-        if (this.ios && this.ios.UIDelegate) this.ios.UIDelegate = null
         this.nativeWrapper.disposeNativeView();
 
         super.disposeNativeView();

--- a/src/webview-ext.ios.ts
+++ b/src/webview-ext.ios.ts
@@ -14,6 +14,23 @@ export const useWKWebView = typeof CustomUrlSchemeHandler !== "undefined";
 export class WebViewExt extends WebViewExtBase {
     protected nativeWrapper: IOSWebViewWrapper;
 
+
+
+    constructor() {
+        super();
+    }
+
+    public loadView() {
+        console.log("WebViewExt loadView()");
+        if (this.viewController && this.nativeWrapper) {
+            this.viewController.view = (<any>this.nativeWrapper).ios;
+        }
+    }
+
+    public getNativeWrapper() {
+        return this.nativeWrapper;
+    }
+
     public get isUIWebView() {
         return !useWKWebView;
     }
@@ -24,23 +41,24 @@ export class WebViewExt extends WebViewExtBase {
 
     public viewPortSize = useWKWebView ? { initialScale: 1.0 } : false;
 
-    public createNativeView() {
+    public createNativeView(existingIOSConfiguration?: WKWebViewConfiguration) {
         if (useWKWebView) {
-            this.nativeWrapper = new WKWebViewWrapper(this);
+            this.nativeWrapper = new WKWebViewWrapper(this, existingIOSConfiguration);
         } else {
             this.nativeWrapper = new UIWebViewWrapper(this);
         }
-
         return this.nativeWrapper.createNativeView();
     }
 
     public initNativeView() {
         super.initNativeView();
-
         this.nativeWrapper.initNativeView();
     }
 
     public disposeNativeView() {
+        if (this.ios && this.ios.navigationDelegate) this.ios.navigationDelegate = null;
+        if (this.ios && this.ios.scrollView.delegate) this.ios.scrollView.delegate = null;
+        if (this.ios && this.ios.UIDelegate) this.ios.UIDelegate = null
         this.nativeWrapper.disposeNativeView();
 
         super.disposeNativeView();
@@ -106,13 +124,11 @@ export class WebViewExt extends WebViewExtBase {
     @profile
     public onLoaded() {
         super.onLoaded();
-
         this.nativeWrapper.onLoaded();
     }
 
     public onUnloaded() {
         this.nativeWrapper.onUnloaded();
-
         super.onUnloaded();
     }
 

--- a/src/webview-ext.wkwebview.ts
+++ b/src/webview-ext.wkwebview.ts
@@ -65,7 +65,7 @@ export class WKNavigationDelegateImpl extends NSObject implements WKNavigationDe
         if (shouldOverrideUrlLoading === true) {
             owner.writeTrace(
                 `WKNavigationDelegateClass.webViewDecidePolicyForNavigationActionDecisionHandler("${url}", "${
-                navigationAction.navigationType
+                    navigationAction.navigationType
                 }") -> method:${httpMethod} "${navType}" -> cancel`,
             );
             decisionHandler(WKNavigationActionPolicy.Cancel);
@@ -75,7 +75,7 @@ export class WKNavigationDelegateImpl extends NSObject implements WKNavigationDe
 
         owner.writeTrace(
             `WKNavigationDelegateClass.webViewDecidePolicyForNavigationActionDecisionHandler("${url}", "${
-            navigationAction.navigationType
+                navigationAction.navigationType
             }") -> method:${httpMethod} "${navType}"`,
         );
         owner._onLoadStarted(url, navType);
@@ -173,22 +173,18 @@ export class WKUIDelegateImpl extends NSObject implements WKUIDelegate {
         return delegate;
     }
 
-    public dealloc() {
-        this.owner = null;
-    }
-
     public deinit() {
         this.owner = null;
     }
 
     /**
-   * Handle window.open requests
-   */
+     * Handle window.open requests
+     */
     public webViewCreateWebViewWithConfigurationForNavigationActionWindowFeatures(
         webView: WKWebView,
         configuration: WKWebViewConfiguration,
         forNavigationAction: WKNavigationAction,
-        windowFeatures: WKWindowFeatures
+        windowFeatures: WKWindowFeatures,
     ): WKWebView {
         const owner = this.owner.get();
         if (!owner) {
@@ -198,7 +194,7 @@ export class WKUIDelegateImpl extends NSObject implements WKUIDelegate {
         let newWKWebView: WKWebView = newNSWebViewExt.createNativeView(configuration);
         newNSWebViewExt.setNativeView(newWKWebView);
 
-        newWKWebView.navigationDelegate = webView.navigationDelegate
+        newWKWebView.navigationDelegate = webView.navigationDelegate;
         newWKWebView.UIDelegate = webView.UIDelegate;
 
         owner.notify({ eventName: "createWebViewWithConfiguration", object: owner, data: newNSWebViewExt });
@@ -366,6 +362,9 @@ export class WKWebViewWrapper implements IOSWebViewWrapper {
         this.wkCustomUrlSchemeHandler = null;
         this.wkUIDelegate && this.wkUIDelegate.deinit();
         this.wkUIDelegate = null;
+        if (this.ios && this.ios.navigationDelegate) this.ios.navigationDelegate = null;
+        if (this.ios && this.ios.scrollView && this.ios.scrollView.delegate) this.ios.scrollView.delegate = null;
+        if (this.ios && this.ios.UIDelegate) this.ios.UIDelegate = null;
     }
 
     public onLoaded() {


### PR DESCRIPTION
Handles child window via webViewCreateWebViewWithConfigurationForNavigationActionWindowFeatures notifying the main NativeScript App with a custom "createWebViewWithConfiguration" event

<!--
We, the rest of the NativeScript community, thank you for your
contribution!
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/Notalib/nativescript-webview-ext/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests are passing.
  - [ ] On Android
  - [ ] On iOS 9
  - [ ] On iOS 10
  - [X] On iOS 11
  - [X] On iOS 12+
- [ ] Tests for the changes are included

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Child window (i.e.: window.open) was not supported

## What is the new behavior?
<!-- Describe the changes. -->
New child window opening is intercepted and handled. An event is raised to notify the main App of the newly created WKWebView.

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!--
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

