### PR TITLE
Update webview-ext.android.ts

### DIFF
--- a/src/webview-ext.android.ts
+++ b/src/webview-ext.android.ts
@@ -488,6 +488,8 @@ export class WebViewExt extends WebViewExtBase {
 
         // Needed for the bridge library
         settings.setJavaScriptEnabled(true);
+        
+        settings.setAllowFileAccess(true); // Needed for Android 11
 
         settings.setBuiltInZoomControls(!!this.builtInZoomControls);
         settings.setDisplayZoomControls(!!this.displayZoomControls);


### PR DESCRIPTION
We must set setAllowFileAccess to true to allow for loading local files on apps targeting android 11
for more info check this,
https://developer.android.com/reference/android/webkit/WebSettings#setAllowFileAccess(boolean)

<!--
We, the rest of the NativeScript community, thank you for your
contribution!
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ x] The PR title follows our guidelines: https://github.com/Notalib/nativescript-webview-ext/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ x] All existing tests are passing.
  - [x ] On Android
  - [x ] On iOS 9
  - [x ] On iOS 10
  - [x ] On iOS 11
  - [ x] On iOS 12+
- [ ] Tests for the changes are included

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
You get ERR_ACCESS_DENIED when trying to load local files to webview on apps targeting android 11

## What is the new behavior?
<!-- Describe the changes. -->
Loading local files on apps targeting android 11 works as expected

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!--
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

