### PR TITLE
cleaned up titlechanged

### DIFF
--- a/src/webview-ext-common.ts
+++ b/src/webview-ext-common.ts
@@ -182,7 +182,7 @@ export enum EventNames {
     LoadProgress = "loadProgress",
     LoadStarted = "loadStarted",
     ShouldOverrideUrlLoading = "shouldOverrideUrlLoading",
-    TitleChanged = "titleChange",
+    TitleChanged = "titleChanged",
     WebAlert = "webAlert",
     WebConfirm = "webConfirm",
     WebConsole = "webConsole",
@@ -258,7 +258,7 @@ export interface LoadProgressEventData extends WebViewExtEventData {
 }
 
 export interface TitleChangedEventData extends WebViewExtEventData {
-    eventName: EventNames.LoadProgress;
+    eventName: EventNames.TitleChanged;
     url: string;
     title: string;
 }


### PR DESCRIPTION
updated the titleChange enum string to titleChanged to maintain consistency and using the titleChange enum in the TitleChangedEventData


Fixes/Implements/Closes #80 .
